### PR TITLE
Merge colcon-cargo code and drop colcon-cargo dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# editor
+*~
+.*~
+\#*#
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -1,16 +1,12 @@
 # Licensed under the Apache License, Version 2.0
 
-from colcon_cargo.package_identification.cargo \
-    import CargoPackageIdentification
-
-from colcon_core.package_identification \
-    import PackageIdentificationExtensionPoint
+from colcon_core.package_identification import PackageIdentificationExtensionPoint
 from colcon_core.plugin_system import satisfies_version
-
 from colcon_ros.package_identification.ros import _get_package
+import toml
 
 
-class AmentCargoPackageIdentification(CargoPackageIdentification):
+class AmentCargoPackageIdentification(PackageIdentificationExtensionPoint):
     """Identify Cargo packages with `Cargo.toml` and `package.xml` files."""
 
     PRIORITY = 160
@@ -18,29 +14,31 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
     def __init__(self):  # noqa: D107
         super().__init__()
         satisfies_version(
-            PackageIdentificationExtensionPoint.EXTENSION_POINT_VERSION,
-            '^1.0')
+            PackageIdentificationExtensionPoint.EXTENSION_POINT_VERSION, "^1.0"
+        )
 
     def identify(self, metadata):  # noqa: D102
-        if metadata.type is not None and metadata.type != 'ament_cargo':
+        if metadata.type is not None and metadata.type != "ament_cargo":
             return
 
-        cargo_toml = metadata.path / 'Cargo.toml'
-        if not cargo_toml.is_file():
-            return
-
-        package_xml = metadata.path / 'package.xml'
+        # Check if package.xml exists
+        package_xml = metadata.path / "package.xml"
         if not package_xml.is_file():
             return
 
-        metadata.type = 'ament_cargo'
+        # Check if Cargo.toml exists
+        cargo_toml = metadata.path / "Cargo.toml"
+        if not cargo_toml.is_file():
+            return
+
+        # Make sure Cargo.toml is not a virutal manifest
+        content = toml.load(str(cargo_toml))
+
+        metadata.type = "ament_cargo"
         pkg = _get_package(str(metadata.path))
 
         if metadata.name is None:
-            metadata.name = pkg['name']
-        metadata.dependencies['build'] = \
-            {dep.name for dep in pkg.build_depends}
-        metadata.dependencies['run'] = \
-            {dep.name for dep in pkg.run_depends}
-        metadata.dependencies['test'] = \
-            {dep.name for dep in pkg.test_depends}
+            metadata.name = pkg["name"]
+        metadata.dependencies["build"] = {dep.name for dep in pkg.build_depends}
+        metadata.dependencies["run"] = {dep.name for dep in pkg.run_depends}
+        metadata.dependencies["test"] = {dep.name for dep in pkg.test_depends}

--- a/colcon_ros_cargo/task/ament_cargo/__init__.py
+++ b/colcon_ros_cargo/task/ament_cargo/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2018 Easymov Robotics
+# Licensed under the Apache License, Version 2.0
+
+import os
+import shutil
+
+from colcon_core.environment_variable import EnvironmentVariable
+
+"""Environment variable to override the Cargo executable"""
+CARGO_COMMAND_ENVIRONMENT_VARIABLE = EnvironmentVariable(
+    'CARGO_COMMAND', 'The full path to the Cargo executable')
+
+
+def which_executable(environment_variable, executable_name):
+    """
+    Determine the path of an executable.
+
+    An environment variable can be used to override the location instead of
+    relying on searching the PATH.
+    :param str environment_variable: The name of the environment variable
+    :param str executable_name: The name of the executable
+    :rtype: str
+    """
+    value = os.getenv(environment_variable)
+    if value:
+        return value
+    return shutil.which(executable_name)
+
+
+CARGO_EXECUTABLE = which_executable(
+    CARGO_COMMAND_ENVIRONMENT_VARIABLE.name, 'cargo')

--- a/colcon_ros_cargo/task/ament_cargo/test.py
+++ b/colcon_ros_cargo/task/ament_cargo/test.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Easymov Robotics
+# Licensed under the Apache License, Version 2.0
+
+import os
+
+from . import CARGO_EXECUTABLE
+from colcon_core.event.test import TestFailure
+from colcon_core.logging import colcon_logger
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.shell import get_command_environment
+from colcon_core.task import run
+from colcon_core.task import TaskExtensionPoint
+
+logger = colcon_logger.getChild(__name__)
+
+
+class CargoTestTask(TaskExtensionPoint):
+    """Test Cargo packages."""
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(TaskExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        pass
+
+    async def test(self, *, additional_hooks=None):  # noqa: D102
+        pkg = self.context.pkg
+        args = self.context.args
+
+        logger.info(
+            "Testing Cargo package in '{args.path}'".format_map(locals()))
+
+        assert os.path.exists(args.build_base)
+
+        test_results_path = os.path.join(args.build_base, 'test_results')
+        os.makedirs(test_results_path, exist_ok=True)
+
+        try:
+            env = await get_command_environment(
+                'test', args.build_base, self.context.dependencies)
+        except RuntimeError as e:
+            logger.error(str(e))
+            return 1
+
+        if CARGO_EXECUTABLE is None:
+            raise RuntimeError("Could not find 'cargo' executable")
+
+        # invoke cargo test
+        rc = await run(
+            self.context,
+            [CARGO_EXECUTABLE, 'test', '-q',
+                '--target-dir', test_results_path],
+            cwd=args.path, env=env)
+
+        if rc.returncode:
+            self.context.put_event_into_queue(TestFailure(pkg.name))
+            # the return code should still be 0
+        return 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
   colcon-core
   # to set an environment variable when a package installs a library
   colcon-library-path
-  colcon-cargo
   colcon-ros
 packages = find:
 tests_require =


### PR DESCRIPTION
This PR merges code from colcon-cargo and drops the dep. The package identification process is slightly changed.

colcon-ros-cargo reuses code from colcon-cargo but has a different ways to identify a Cargo package.
colcon-cargo treats virtual Cargo.toml (i.e. workspace) as an individual colcon package. It was discussed in colcon/colcon-cargo#17. OTOH, colcon-ros-cargo checks whether `package.xml` co-exists, but requires colcon-cargo as its dependency. It cannot prevent colcon-cargo from throwing errors due to virtual manifests. This PR fixes the issue by dropping colcon-cargo dependency.
