### PR TITLE
Fix environment hook for correct environment setup in install folder

### DIFF
--- a/colcon_ros_cargo/task/ament_cargo/build.py
+++ b/colcon_ros_cargo/task/ament_cargo/build.py
@@ -73,7 +73,7 @@ class AmentCargoBuildTask(CargoBuildTask):
             Path(self.context.args.install_base),
             self.context.pkg.name,
             'AMENT_PREFIX_PATH',
-            self.context.args.install_base,
+            '',
             mode='prepend')
 
     def _build_cmd(self, cargo_args):


### PR DESCRIPTION
Hi,
currently, colcon-ros-cargo's main branch generates environment hooks that add the absolute path to a package's install location as it was at build-time to the AMENT_PREFIX_PATH. As a result, the generated install folder cannot be moved to another location without breaking the environment setup. 

This pull-request fixes this (at least for our Galactic workspace). According to https://colcon.readthedocs.io/en/released/developer/environment.html, passing '' will result in prepend-non-duplicate interpreting this as a relative path to which it adds "...the prefix path of the .dsv file...". 

Disclaimer: I'm not very familiar with the colcon environment setup, so there might be a more correct way to fix this. 