### PR TITLE
Clearer error message if cargo.toml is not found

### DIFF
--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -3,13 +3,15 @@
 from colcon_cargo.package_identification.cargo \
     import CargoPackageIdentification
 
+from catkin_pkg.package import parse_package
 
-from colcon_core.package_identification import logger
+from colcon_core.logging import colcon_logger
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
 from colcon_core.plugin_system import satisfies_version
 from colcon_ros.package_identification.ros import _get_package
 
+logger = colcon_logger.getChild(__name__)
 
 class AmentCargoPackageIdentification(CargoPackageIdentification):
     """Identify Cargo packages with `Cargo.toml` and `package.xml` files."""
@@ -23,7 +25,6 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
             '^1.0')
 
     def identify(self, metadata):  # noqa: D102
-        from catkin_pkg.package import parse_package
 
         if metadata.type is not None and metadata.type != 'ament_cargo':
             return
@@ -40,7 +41,7 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
         cargo_toml = metadata.path / 'Cargo.toml'
         if not cargo_toml.is_file():
             logger.warn('Got build type ament_cargo but could not find "Cargo.toml"')
-            raise RuntimeError('Got build type ament_cargo but could not find "Cargo.toml"')
+            return
        
         metadata.type = 'ament_cargo'
         pkg = _get_package(str(metadata.path))

--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -1,10 +1,8 @@
 # Licensed under the Apache License, Version 2.0
 
+from catkin_pkg.package import parse_package
 from colcon_cargo.package_identification.cargo \
     import CargoPackageIdentification
-
-from catkin_pkg.package import parse_package
-
 from colcon_core.logging import colcon_logger
 from colcon_core.package_identification \
     import PackageIdentificationExtensionPoint
@@ -12,6 +10,7 @@ from colcon_core.plugin_system import satisfies_version
 from colcon_ros.package_identification.ros import _get_package
 
 logger = colcon_logger.getChild(__name__)
+
 
 class AmentCargoPackageIdentification(CargoPackageIdentification):
     """Identify Cargo packages with `Cargo.toml` and `package.xml` files."""
@@ -40,9 +39,10 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
 
         cargo_toml = metadata.path / 'Cargo.toml'
         if not cargo_toml.is_file():
-            logger.warn('Got build type ament_cargo but could not find "Cargo.toml"')
+            logger.warn(
+                'Got build type ament_cargo but could not find "Cargo.toml"')
             return
-       
+
         metadata.type = 'ament_cargo'
         pkg = _get_package(str(metadata.path))
 


### PR DESCRIPTION
Currently if a `Cargo.toml` is missing or has the wrong name, the error message is not very clearly formatted. This PR will give a clear log output if `ament_cargo` is selected and we are missing a `Cargo.toml`.