### PR TITLE
ignore cmake projects

### DIFF
--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -25,6 +25,10 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
         if metadata.type is not None and metadata.type != 'ament_cargo':
             return
 
+        cmakelists = metadata.path / 'CMakeLists.txt'
+        if cmakelists.is_file():
+            return
+        
         cargo_toml = metadata.path / 'Cargo.toml'
         if not cargo_toml.is_file():
             return


### PR DESCRIPTION
The r2r project still uses CMake for building the nodes in the minimal node example. This PR ignores packages containing `CMakeLists.txt` to allow both libraries to be used for writing ROS nodes.

The plugin still can compile the r2r node but it leads to problems as described [here](https://github.com/m-dahl/r2r_minimal_node/issues/8). I don't really understand the need for colcon-cargo and colcon-ros-cargo at the same time as described in the ros2_rust Readme so I did the PR at both repositories. It seems like the relevant plugin for my system is colcon-ros-cargo though.