### PR TITLE
Colcon Test Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# editor
+*~
+.*~
+\#*#
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -18,5 +18,3 @@ After building, run binaries with `ros2 run`.
 This is by far not a perfect build system.
 
 Notably, there is _quadratic_ build cost as a function of the dependency chain length. To illustrate this, assume there are packages A, B and C, where C depends on B and B depends on A. If colcon builds this workspace, it builds A first, then B, then C. However, Cargo will _also_ build all the dependencies, i.e., to build B, Cargo will build A again, and to build C, it will build A and B again.
-
-`colcon test` is not yet supported.

--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -1,16 +1,12 @@
 # Licensed under the Apache License, Version 2.0
 
-from colcon_cargo.package_identification.cargo \
-    import CargoPackageIdentification
-
-from colcon_core.package_identification \
-    import PackageIdentificationExtensionPoint
+from colcon_core.package_identification import PackageIdentificationExtensionPoint
 from colcon_core.plugin_system import satisfies_version
-
 from colcon_ros.package_identification.ros import _get_package
+import toml
 
 
-class AmentCargoPackageIdentification(CargoPackageIdentification):
+class AmentCargoPackageIdentification(PackageIdentificationExtensionPoint):
     """Identify Cargo packages with `Cargo.toml` and `package.xml` files."""
 
     PRIORITY = 160
@@ -18,29 +14,31 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
     def __init__(self):  # noqa: D107
         super().__init__()
         satisfies_version(
-            PackageIdentificationExtensionPoint.EXTENSION_POINT_VERSION,
-            '^1.0')
+            PackageIdentificationExtensionPoint.EXTENSION_POINT_VERSION, "^1.0"
+        )
 
     def identify(self, metadata):  # noqa: D102
-        if metadata.type is not None and metadata.type != 'ament_cargo':
+        if metadata.type is not None and metadata.type != "ament_cargo":
             return
 
-        cargo_toml = metadata.path / 'Cargo.toml'
-        if not cargo_toml.is_file():
-            return
-
-        package_xml = metadata.path / 'package.xml'
+        # Check if package.xml exists
+        package_xml = metadata.path / "package.xml"
         if not package_xml.is_file():
             return
 
-        metadata.type = 'ament_cargo'
+        # Check if Cargo.toml exists
+        cargo_toml = metadata.path / "Cargo.toml"
+        if not cargo_toml.is_file():
+            return
+
+        # Make sure Cargo.toml is not a virutal manifest
+        content = toml.load(str(cargo_toml))
+
+        metadata.type = "ament_cargo"
         pkg = _get_package(str(metadata.path))
 
         if metadata.name is None:
-            metadata.name = pkg['name']
-        metadata.dependencies['build'] = \
-            {dep.name for dep in pkg.build_depends}
-        metadata.dependencies['run'] = \
-            {dep.name for dep in pkg.run_depends}
-        metadata.dependencies['test'] = \
-            {dep.name for dep in pkg.test_depends}
+            metadata.name = pkg["name"]
+        metadata.dependencies["build"] = {dep.name for dep in pkg.build_depends}
+        metadata.dependencies["run"] = {dep.name for dep in pkg.run_depends}
+        metadata.dependencies["test"] = {dep.name for dep in pkg.test_depends}

--- a/colcon_ros_cargo/task/ament_cargo/__init__.py
+++ b/colcon_ros_cargo/task/ament_cargo/__init__.py
@@ -1,0 +1,31 @@
+# Copyright 2018 Easymov Robotics
+# Licensed under the Apache License, Version 2.0
+
+import os
+import shutil
+
+from colcon_core.environment_variable import EnvironmentVariable
+
+"""Environment variable to override the Cargo executable"""
+CARGO_COMMAND_ENVIRONMENT_VARIABLE = EnvironmentVariable(
+    'CARGO_COMMAND', 'The full path to the Cargo executable')
+
+
+def which_executable(environment_variable, executable_name):
+    """
+    Determine the path of an executable.
+
+    An environment variable can be used to override the location instead of
+    relying on searching the PATH.
+    :param str environment_variable: The name of the environment variable
+    :param str executable_name: The name of the executable
+    :rtype: str
+    """
+    value = os.getenv(environment_variable)
+    if value:
+        return value
+    return shutil.which(executable_name)
+
+
+CARGO_EXECUTABLE = which_executable(
+    CARGO_COMMAND_ENVIRONMENT_VARIABLE.name, 'cargo')

--- a/colcon_ros_cargo/task/ament_cargo/test.py
+++ b/colcon_ros_cargo/task/ament_cargo/test.py
@@ -14,7 +14,7 @@ from colcon_core.task import TaskExtensionPoint
 logger = colcon_logger.getChild(__name__)
 
 
-class CargoTestTask(TaskExtensionPoint):
+class AmentCargoTestTask(TaskExtensionPoint):
     """Test Cargo packages."""
 
     def __init__(self):  # noqa: D107

--- a/colcon_ros_cargo/task/ament_cargo/test.py
+++ b/colcon_ros_cargo/task/ament_cargo/test.py
@@ -56,4 +56,13 @@ class AmentCargoTestTask(TaskExtensionPoint):
         if rc.returncode:
             self.context.put_event_into_queue(TestFailure(pkg.name))
             # the return code should still be 0
+            return 0
+
+        rc = await run(
+            self.context,
+            [CARGO_EXECUTABLE, 'fmt', '--check'],
+            cwd=args.path, env=env, capture_output=True)
+        if rc.returncode:
+            self.context.put_event_into_queue(TestFailure(pkg.name))
+
         return 0

--- a/colcon_ros_cargo/task/ament_cargo/test.py
+++ b/colcon_ros_cargo/task/ament_cargo/test.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Easymov Robotics
+# Licensed under the Apache License, Version 2.0
+
+import os
+
+from . import CARGO_EXECUTABLE
+from colcon_core.event.test import TestFailure
+from colcon_core.logging import colcon_logger
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.shell import get_command_environment
+from colcon_core.task import run
+from colcon_core.task import TaskExtensionPoint
+
+logger = colcon_logger.getChild(__name__)
+
+
+class CargoTestTask(TaskExtensionPoint):
+    """Test Cargo packages."""
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(TaskExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        pass
+
+    async def test(self, *, additional_hooks=None):  # noqa: D102
+        pkg = self.context.pkg
+        args = self.context.args
+
+        logger.info(
+            "Testing Cargo package in '{args.path}'".format_map(locals()))
+
+        assert os.path.exists(args.build_base)
+
+        test_results_path = os.path.join(args.build_base, 'test_results')
+        os.makedirs(test_results_path, exist_ok=True)
+
+        try:
+            env = await get_command_environment(
+                'test', args.build_base, self.context.dependencies)
+        except RuntimeError as e:
+            logger.error(str(e))
+            return 1
+
+        if CARGO_EXECUTABLE is None:
+            raise RuntimeError("Could not find 'cargo' executable")
+
+        # invoke cargo test
+        rc = await run(
+            self.context,
+            [CARGO_EXECUTABLE, 'test', '-q',
+                '--target-dir', test_results_path],
+            cwd=args.path, env=env)
+
+        if rc.returncode:
+            self.context.put_event_into_queue(TestFailure(pkg.name))
+            # the return code should still be 0
+        return 0

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ install_requires =
   colcon-core
   # to set an environment variable when a package installs a library
   colcon-library-path
-  colcon-cargo
   colcon-ros
 packages = find:
 tests_require =

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,8 @@ colcon_core.package_identification =
     ament_cargo = colcon_ros_cargo.package_identification.ament_cargo:AmentCargoPackageIdentification
 colcon_core.task.build =
     ament_cargo = colcon_ros_cargo.task.ament_cargo.build:AmentCargoBuildTask
+colcon_core.task.test =
+    ament_cargo = colcon_ros_cargo.task.ament_cargo.test:AmentCargoTestTask
 
 [flake8]
 import-order-style = google


### PR DESCRIPTION
Piggybacking from jerry73204 work.

- Added colcon test support
- Added formatting check

The major problem with running `colcon test` is that if cargo fmt fails you won't be able to see the incorrect formatting failures unless you run event_handlers to print to stdout