### PR TITLE
Fix long_description in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,8 @@ classifiers =
     Topic :: Software Development :: Build Tools
 license = Apache License, Version 2.0
 description = Extension for colcon to support Ament Cargo packages.
-long_description = file: README.rst
+long_description = file: README.md
+long_description_content_type = text/markdown
 keywords = colcon
 
 [options]


### PR DESCRIPTION
Should resolve warnings like:
```
/usr/lib/python3/dist-packages/setuptools/config/expand.py:134: SetuptoolsWarning: File 'src/colcon-ros-cargo/README.rst' cannot be found
```