### PR TITLE
Add github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,13 @@
+---
+name: Run tests
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+
+jobs:
+  pytest:
+    uses: colcon/ci/.github/workflows/pytest.yaml@main
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,8 +33,11 @@ install_requires =
   colcon-cargo
   colcon-ros
 packages = find:
-tests_require =
-  flake8
+zip_safe = true
+
+[options.extras_require]
+test =
+  flake8>=3.6.0
   flake8-blind-except
   flake8-builtins
   flake8-class-newline
@@ -44,11 +47,10 @@ tests_require =
   flake8-import-order
   flake8-quotes
   pep8-naming
-  pyenchant
   pylint
   pytest
   pytest-cov
-zip_safe = true
+  scspell3k>=2.2
 
 [options.entry_points]
 colcon_core.package_identification =

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,6 +52,21 @@ test =
   pytest-cov
   scspell3k>=2.2
 
+[tool:pytest]
+filterwarnings =
+    error
+    # Suppress deprecation warnings in other packages
+    ignore:lib2to3 package is deprecated::scspell
+    ignore:pkg_resources is deprecated as an API::flake8_import_order
+    ignore:SelectableGroups dict interface is deprecated::flake8
+    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated::pyreadline
+    ignore:the imp module is deprecated in favour of importlib.*:DeprecationWarning
+    ignore:the imp module is deprecated in favour of importlib.*:PendingDeprecationWarning
+junit_suite_name = colcon-ros-cargo
+markers =
+    flake8
+    linter
+
 [options.entry_points]
 colcon_core.package_identification =
     ament_cargo = colcon_ros_cargo.package_identification.ament_cargo:AmentCargoPackageIdentification

--- a/test/test_flake8.py
+++ b/test/test_flake8.py
@@ -1,9 +1,53 @@
 # Licensed under the Apache License, Version 2.0
 
-from flake8.api import legacy as flake8
+import logging
 from pathlib import Path
+import sys
 
-style_guide = flake8.get_style_guide(ignore=['D100', 'D104'], show_source=True)
-plugin_path = str(Path(__file__).parents[1] / 'colcon_ros_cargo')
-report = style_guide.check_files([plugin_path])
-assert report.get_statistics('E') == [], 'Flake8 found violations'
+import pytest
+
+
+@pytest.mark.flake8
+@pytest.mark.linter
+def test_flake8():
+    from flake8.api.legacy import get_style_guide
+
+    # avoid debug / info / warning messages from flake8 internals
+    logging.getLogger('flake8').setLevel(logging.ERROR)
+
+    # for some reason the pydocstyle logger changes to an effective level of 1
+    # set higher level to prevent the output to be flooded with debug messages
+    logging.getLogger('pydocstyle').setLevel(logging.WARNING)
+
+    style_guide = get_style_guide(
+        extend_ignore=['D100', 'D104'],
+        show_source=True,
+    )
+    style_guide_tests = get_style_guide(
+        extend_ignore=['D100', 'D101', 'D102', 'D103', 'D104', 'D105', 'D107'],
+        show_source=True,
+    )
+
+    stdout = sys.stdout
+    sys.stdout = sys.stderr
+    # implicitly calls report_errors()
+    report = style_guide.check_files([
+        str(Path(__file__).parents[1] / 'colcon_ros_cargo'),
+    ])
+    report_tests = style_guide_tests.check_files([
+        str(Path(__file__).parents[1] / 'test'),
+    ])
+    sys.stdout = stdout
+
+    total_errors = report.total_errors + report_tests.total_errors
+    if total_errors:  # pragma: no cover
+        # output summary with per-category counts
+        print()
+        if report.total_errors:
+            report._application.formatter.show_statistics(report._stats)
+        if report_tests.total_errors:
+            report_tests._application.formatter.show_statistics(
+                report_tests._stats)
+        print(f'flake8 reported {total_errors} errors', file=sys.stderr)
+
+    assert not total_errors, f'flake8 reported {total_errors} errors'


### PR DESCRIPTION
Copied from `colcon-cargo`. For now only tests flake8, followup PR will contain the tests themselves but I suspect they might be blocked on `colcon-cargo` being released