### PR TITLE
Add colcon test verb

### DIFF
--- a/colcon_ros_cargo/task/ament_cargo/build.py
+++ b/colcon_ros_cargo/task/ament_cargo/build.py
@@ -92,6 +92,10 @@ class AmentCargoBuildTask(CargoBuildTask):
             '--tests',
         ] + cargo_args
 
+    # Installation is done by cargo ament-build
+    def _install_cmd(self, cargo_args):  #noqa: D102
+        pass
+
 
 def write_cargo_config_toml(package_paths):
     """Write the resolved package paths to config.toml.

--- a/colcon_ros_cargo/task/ament_cargo/build.py
+++ b/colcon_ros_cargo/task/ament_cargo/build.py
@@ -86,10 +86,7 @@ class AmentCargoBuildTask(CargoBuildTask):
             '--',
             '--manifest-path', manifest_path,
             '--target-dir', args.build_base,
-            '--quiet',
-            '--lib',
-            '--bins',
-            '--tests',
+            '--quiet'
         ] + cargo_args
 
     # Installation is done by cargo ament-build

--- a/colcon_ros_cargo/task/ament_cargo/build.py
+++ b/colcon_ros_cargo/task/ament_cargo/build.py
@@ -86,7 +86,10 @@ class AmentCargoBuildTask(CargoBuildTask):
             '--',
             '--manifest-path', manifest_path,
             '--target-dir', args.build_base,
-            '--quiet'
+            '--quiet',
+            '--lib',
+            '--bins',
+            '--tests',
         ] + cargo_args
 
 

--- a/colcon_ros_cargo/task/ament_cargo/build.py
+++ b/colcon_ros_cargo/task/ament_cargo/build.py
@@ -93,7 +93,7 @@ class AmentCargoBuildTask(CargoBuildTask):
         ] + cargo_args
 
     # Installation is done by cargo ament-build
-    def _install_cmd(self, cargo_args):  #noqa: D102
+    def _install_cmd(self, cargo_args):  # noqa: D102
         pass
 
 

--- a/colcon_ros_cargo/task/ament_cargo/test.py
+++ b/colcon_ros_cargo/task/ament_cargo/test.py
@@ -16,3 +16,6 @@ class AmentCargoTestTask(CargoTestTask):
     def __init__(self):  # noqa: D107
         super().__init__()
         satisfies_version(TaskExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        pass

--- a/colcon_ros_cargo/task/ament_cargo/test.py
+++ b/colcon_ros_cargo/task/ament_cargo/test.py
@@ -16,8 +16,3 @@ class AmentCargoTestTask(CargoTestTask):
     def __init__(self):  # noqa: D107
         super().__init__()
         satisfies_version(TaskExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
-
-    def add_arguments(self, *, parser):  # noqa: D102
-        pass
-
-    # def _test_cmd(self, cargo_args):

--- a/colcon_ros_cargo/task/ament_cargo/test.py
+++ b/colcon_ros_cargo/task/ament_cargo/test.py
@@ -1,0 +1,23 @@
+# Licensed under the Apache License, Version 2.0
+
+from colcon_cargo.task.cargo.test import CargoTestTask
+from colcon_core.plugin_system import satisfies_version
+from colcon_core.task import TaskExtensionPoint
+
+
+class AmentCargoTestTask(CargoTestTask):
+    """A test task for packages with Cargo.toml + package.xml.
+
+    Tests are already built by `colcon build` so this task only needs to
+    run them and doesn't need to worry about dependency management
+    (unlike the `AmentCargoBuildTask`).
+    """
+
+    def __init__(self):  # noqa: D107
+        super().__init__()
+        satisfies_version(TaskExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+    def add_arguments(self, *, parser):  # noqa: D102
+        pass
+
+    # def _test_cmd(self, cargo_args):

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,8 @@ colcon_core.package_identification =
     ament_cargo = colcon_ros_cargo.package_identification.ament_cargo:AmentCargoPackageIdentification
 colcon_core.task.build =
     ament_cargo = colcon_ros_cargo.task.ament_cargo.build:AmentCargoBuildTask
+colcon_core.task.test =
+    ament_cargo = colcon_ros_cargo.task.ament_cargo.test:AmentCargoTestTask
 
 [flake8]
 import-order-style = google


### PR DESCRIPTION
Closes #8 
Depends on https://github.com/colcon/colcon-cargo/pull/39.

I did some back and forth between whether `cargo build` should also build tests or not. In the end I settled on "no" because doing so would require passing custom arguments as shown in https://github.com/colcon/colcon-ros-cargo/pull/19/commits/e80cddfbf636484854f06ca1a0a82e80ba9287bc.
However, a `cargo build` custom command would fail if the underlying package is missing any of the required components, for example if there are no libraries or if there are no binaries.
The alternative would have been to try to parse the package and generate the correct `cargo build` invocation, but that would have made the implementation fairly more complex.

The implementation of the actual test takes place in `colcon-cargo` so this PR is pretty bare.