### PR TITLE
Warn user if cargo ament build is not installed

### DIFF
--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -47,10 +47,12 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
 
         ament_build = 'cargo ament-build --help'.split()
         if subprocess.run(ament_build, capture_output=True).returncode != 0:
-            logger.error(
-                'ament_cargo package found but cargo ament-build was not '
-                'detected. Please install it by running: '
-                '`cargo install cargo-ament-build`')
+            if print_ament_cargo_warning_once():
+                logger.error(
+                    '\n\nament_cargo package found but cargo ament-build was not '
+                    'detected.'
+                    '\n\nPlease install it by running:'
+                    '\n $ cargo install cargo-ament-build\n')
             return
 
         metadata.type = 'ament_cargo'
@@ -64,3 +66,19 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
             {dep.name for dep in pkg.run_depends}
         metadata.dependencies['test'] = \
             {dep.name for dep in pkg.test_depends}
+
+def print_ament_cargo_warning_once():
+    global has_printed_ament_cargo_warning
+    try:
+        # The following line will throw an exception if the global variable
+        # has never been initialized
+        has_printed_ament_cargo_warning
+    except NameError:
+        # We want to initialize the global variable to false the first time
+        has_printed_ament_cargo_warning = False
+
+    if not has_printed_ament_cargo_warning:
+        has_printed_ament_cargo_warning = True
+        return True
+
+    return False

--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -47,10 +47,10 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
 
         ament_build = 'cargo ament-build --help'.split()
         if subprocess.run(ament_build, capture_output=True).returncode != 0:
-            if print_ament_cargo_warning_once():
+            if _print_ament_cargo_warning_once():
                 logger.error(
-                    '\n\nament_cargo package found but cargo ament-build was not '
-                    'detected.'
+                    '\n\nament_cargo package found but cargo ament-build was '
+                    'not detected.'
                     '\n\nPlease install it by running:'
                     '\n $ cargo install cargo-ament-build\n')
             return
@@ -67,7 +67,8 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
         metadata.dependencies['test'] = \
             {dep.name for dep in pkg.test_depends}
 
-def print_ament_cargo_warning_once():
+
+def _print_ament_cargo_warning_once():
     global has_printed_ament_cargo_warning
     try:
         # The following line will throw an exception if the global variable

--- a/colcon_ros_cargo/package_identification/ament_cargo.py
+++ b/colcon_ros_cargo/package_identification/ament_cargo.py
@@ -1,5 +1,7 @@
 # Licensed under the Apache License, Version 2.0
 
+import subprocess
+
 from catkin_pkg.package import parse_package
 from colcon_cargo.package_identification.cargo \
     import CargoPackageIdentification
@@ -41,6 +43,14 @@ class AmentCargoPackageIdentification(CargoPackageIdentification):
         if not cargo_toml.is_file():
             logger.warn(
                 'Got build type ament_cargo but could not find "Cargo.toml"')
+            return
+
+        ament_build = 'cargo ament-build --help'.split()
+        if subprocess.run(ament_build, capture_output=True).returncode != 0:
+            logger.error(
+                'ament_cargo package found but cargo ament-build was not '
+                'detected. Please install it by running: '
+                '`cargo install cargo-ament-build`')
             return
 
         metadata.type = 'ament_cargo'


### PR DESCRIPTION
This PR returns an error if `cargo-ament-build` was not found, including a message on how to install it, it's pretty straightforward but a few notes:

* I opted to recommend for using `cargo install cargo-ament-build` as noted in the [ros2-rust README](https://github.com/ros2-rust/ros2_rust), I thought about recommending pip but then it would cause a lot of trouble on 24.04 because virtual envs etc.
* I thought of falling back to a `colcon-cargo` package but I'm not 100% convinced it is a good idea to silently continue building with a build type different from what the users might expect, instead of loudly printing an error and failing.
* The failure method of this package identification is a bit odd and I'm not 100% sure it is the right thing to do, specifics below in the `Test it!` section.

### Test it!

* Copy the [sample package](https://github.com/colcon/colcon-ros-cargo/tree/main/test/rust-sample-package) into a colcon workspace
* Try a colcon build with `cargo ament-build` installed
* Remove `cargo-ament-build`
* Try again

You should see the (as I mentioned above slightly strange) failure:

```
lucadv@ros:~/colcon_ws$ colcon build
[0.241s] ERROR:colcon.colcon_ros_cargo.package_identification.ament_cargo:ament_cargo package found but cargo ament-build was not detected. Please install it by running: `cargo install cargo-ament-build`
[0.332s] WARNING:colcon.colcon_core.verb:No task extension to 'build' a 'ros.ament_cargo' package
```

Specifically the second warning is a bit odd but it will happen in all our error paths, so we should probably do something more than early returning on failure, but that is something out of scope for this specific PR