### PR TITLE
Make workspace relocatable by using relative subdirectory.

### DIFF
--- a/colcon_ros_cargo/task/ament_cargo/build.py
+++ b/colcon_ros_cargo/task/ament_cargo/build.py
@@ -83,7 +83,7 @@ class AmentCargoBuildTask(CargoBuildTask):
             Path(self.context.args.install_base),
             self.context.pkg.name,
             'AMENT_PREFIX_PATH',
-            self.context.args.install_base,
+            '',
             mode='prepend')
 
     def _build_cmd(self, cargo_args):


### PR DESCRIPTION
According to colcon-core, the subdirectory parametre should be a relative path to use the COLCON_CURRENT_PREFIX and make the workspace relocatable.

See #33