### PR TITLE
fix: Preserve existing config.toml entries that are not managed by this tool

### DIFF
--- a/colcon_ros_cargo/task/ament_cargo/build.py
+++ b/colcon_ros_cargo/task/ament_cargo/build.py
@@ -125,9 +125,7 @@ def write_cargo_config_toml(package_paths):
         content['patch'] = {}
 
     # remove old entries
-    content['patch']['crates-io'] = {}
-
-    content['patch']['crates-io'].update(patches)
+    content['patch']['crates-io'] = patches
 
     with cargo_config_toml_out.open('w') as toml_file:
         toml.dump(content, toml_file)

--- a/colcon_ros_cargo/task/ament_cargo/build.py
+++ b/colcon_ros_cargo/task/ament_cargo/build.py
@@ -110,10 +110,25 @@ def write_cargo_config_toml(package_paths):
     :param package_paths: A mapping of package names to paths
     """
     patches = {pkg: {'path': str(path)} for pkg, path in package_paths.items()}
-    content = {'patch': {'crates-io': patches}}
+
     config_dir = Path.cwd() / '.cargo'
     config_dir.mkdir(exist_ok=True)
     cargo_config_toml_out = config_dir / 'config.toml'
+
+    if cargo_config_toml_out.exists():
+        with cargo_config_toml_out.open('r') as toml_file:
+            content = toml.load(toml_file)
+    else:
+        content = {}
+
+    if 'patch' not in content:
+        content['patch'] = {}
+
+    # remove old entries
+    content['patch']['crates-io'] = {}
+
+    content['patch']['crates-io'].update(patches)
+
     with cargo_config_toml_out.open('w') as toml_file:
         toml.dump(content, toml_file)
 

--- a/test/test_cargo_config_toml.py
+++ b/test/test_cargo_config_toml.py
@@ -40,8 +40,8 @@ def test_write_cargo_config_toml_creates_new_file(temp_workspace):
     }
 
 
-def test_write_cargo_config_toml_overwrites_existing(temp_workspace):
-    """Test that the implementation overwrites existing config.toml."""
+def test_write_cargo_config_toml_merges_entries(temp_workspace):
+    """Test that the it merges its changes and preserves existing config."""
     config_dir = temp_workspace / ".cargo"
     config_dir.mkdir(exist_ok=True)
     config_file = config_dir / "config.toml"
@@ -70,8 +70,43 @@ def test_write_cargo_config_toml_overwrites_existing(temp_workspace):
     with config_file.open("r") as f:
         content = toml.load(f)
 
-    assert "build" not in content
+    # Existing config is preserved
+    assert content["build"]["target"] == "x86_64-unknown-linux-gnu"
+    assert content["build"]["jobs"] == 4
+
+    # Old crates-io patch is removed
     assert "existing_package" not in content["patch"]["crates-io"]
+
+    # New crates-io patch is present
     assert content["patch"]["crates-io"]["new_package"] == {
         "path": "/path/to/new_package"
     }
+
+
+def test_write_cargo_config_toml_updates_existing_patch(temp_workspace):
+    """Test that updating an existing patch overwrites it."""
+    config_dir = temp_workspace / ".cargo"
+    config_dir.mkdir(exist_ok=True)
+    config_file = config_dir / "config.toml"
+
+    existing_content = {
+        "patch": {
+            "crates-io": {
+                "my_package": {"path": "/old/path"},
+            }
+        }
+    }
+
+    with config_file.open("w") as f:
+        toml.dump(existing_content, f)
+
+    package_paths = {
+        "my_package": Path("/new/path"),
+    }
+
+    write_cargo_config_toml(package_paths)
+
+    with config_file.open("r") as f:
+        content = toml.load(f)
+
+    assert content["patch"]["crates-io"]["my_package"] == {"path": "/new/path"}

--- a/test/test_cargo_config_toml.py
+++ b/test/test_cargo_config_toml.py
@@ -1,0 +1,77 @@
+import pytest
+from pathlib import Path
+import toml
+import os
+
+from colcon_ros_cargo.task.ament_cargo.build import write_cargo_config_toml
+
+
+@pytest.fixture
+def temp_workspace(tmp_path):
+    """Create a temporary workspace directory."""
+    original_cwd = os.getcwd()
+    os.chdir(tmp_path)
+    yield tmp_path
+    os.chdir(original_cwd)
+
+
+def test_write_cargo_config_toml_creates_new_file(temp_workspace):
+    """Test that config.toml is created when it doesn't exist."""
+    package_paths = {
+        "my_package": Path("/path/to/my_package"),
+        "other_package": Path("/path/to/other_package"),
+    }
+
+    write_cargo_config_toml(package_paths)
+
+    config_file = temp_workspace / ".cargo" / "config.toml"
+    assert config_file.exists()
+
+    with config_file.open("r") as f:
+        content = toml.load(f)
+
+    assert "patch" in content
+    assert "crates-io" in content["patch"]
+    assert content["patch"]["crates-io"]["my_package"] == {
+        "path": "/path/to/my_package"
+    }
+    assert content["patch"]["crates-io"]["other_package"] == {
+        "path": "/path/to/other_package"
+    }
+
+
+def test_write_cargo_config_toml_overwrites_existing(temp_workspace):
+    """Test that the implementation overwrites existing config.toml."""
+    config_dir = temp_workspace / ".cargo"
+    config_dir.mkdir(exist_ok=True)
+    config_file = config_dir / "config.toml"
+
+    existing_content = {
+        "build": {
+            "target": "x86_64-unknown-linux-gnu",
+            "jobs": 4,
+        },
+        "patch": {
+            "crates-io": {
+                "existing_package": {"path": "/existing/path"},
+            }
+        },
+    }
+
+    with config_file.open("w") as f:
+        toml.dump(existing_content, f)
+
+    package_paths = {
+        "new_package": Path("/path/to/new_package"),
+    }
+
+    write_cargo_config_toml(package_paths)
+
+    with config_file.open("r") as f:
+        content = toml.load(f)
+
+    assert "build" not in content
+    assert "existing_package" not in content["patch"]["crates-io"]
+    assert content["patch"]["crates-io"]["new_package"] == {
+        "path": "/path/to/new_package"
+    }


### PR DESCRIPTION
I am working in a cargo workspace and want to use rclrs in some of the packages. The current implementation however takes strong ownership of this, and in particular replaces existing `.cargo/config.toml` files. I have:

```toml
[target.aarch64-unknown-linux-gnu]
linker = "aarch64-linux-gnu-gcc"
```

after running this tool, it is replaced with:
```toml
[patch.crates-io.rclrs]
path = "/home/foo/install/rclrs/share/rclrs/rust"
...
```

This PR changes the behaviour of `write_cargo_config_toml()` to keep existing entries that are not part of a `[patch.crates-io]` section, while replacing all of the existing `[patch.crates-io]`. Replacing (instead of appending) keeps the functionality identical with the current implementation.

The PR additionally introduces unit tests for the specific function.

This PR can be reviewed commit-by-commit. The first commit adds a unit test to test the existing behaviour, the second commit introduces the change and modifies the unit test to verify the new behaviour. 

Note: AI was used for this PR

I didn't use a code formatter for `build.py` as I couldn't find any guidelines or config for common tooling. Using `ruff` heavily modifies it so I raw-dogged it.
